### PR TITLE
Added qit qm plugin

### DIFF
--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -28,7 +28,10 @@
 				".",
 				"https://downloads.wordpress.org/plugin/akismet.zip",
 				"https://github.com/WP-API/Basic-Auth/archive/master.zip",
-				"https://downloads.wordpress.org/plugin/wp-mail-logging.zip"
+				"https://downloads.wordpress.org/plugin/wp-mail-logging.zip",
+				"https://downloads.wordpress.org/plugin/query-monitor.3.15.0.zip",
+				"./qm-alloptions/",
+				"./qit-qm-summary/"
 			],
 			"themes": [
 				"https://downloads.wordpress.org/theme/twentynineteen.zip"

--- a/plugins/woocommerce/qit-qm-summary/api/result-summary.php
+++ b/plugins/woocommerce/qit-qm-summary/api/result-summary.php
@@ -1,0 +1,183 @@
+<?php
+
+use WP_REST_Request;
+
+if ( ! class_exists( 'QM_Result_Summary' ) ) {
+    class QM_Result_Summary {
+        protected string $endpoint                    = 'result-summary';
+        protected static ?QM_Result_Summary $instance = null;
+
+        public static function instance() {
+
+            if ( is_null( self::$instance ) ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        public function init() {
+            add_action( 'rest_api_init', [ $this, 'register_route' ] );
+        }
+
+        public function register_route() {
+            register_rest_route( 
+                'qm/v1', 
+                $this->endpoint, 
+                [
+                    'methods'             => 'GET',
+                    'callback'            => [ $this, 'get_summary' ],
+                    'permission_callback' => '__return_true'
+                ] 
+            );
+        }
+
+        public function base64url_decode( string $url ): string {
+            return base64_decode( str_pad( strtr( $url, '-_', '+/' ), strlen( $url ) % 4, '=', STR_PAD_RIGHT ) );
+        }
+        
+        
+        public function aggregate_data( string $type ): array {
+            $root_dir    = __DIR__ . '/../results/' .  $type; // Change this to your directory path
+            $directories = new DirectoryIterator( $root_dir );
+            $all_data    = [];
+            
+            foreach ( $directories as $dir ) {
+                if ( $dir->isDot() || !$dir->isDir() ) {
+                    continue; // Skip non-directories and dot references
+                }
+            
+                $dir_name         = $dir->getFilename();
+                $key              = $this->base64url_decode( $dir_name );
+                $all_data[ $key ] = []; // Initialize an array for this directory
+            
+                // Iterate over the JSON files in the current directory
+                $json_files = new FilesystemIterator( $dir->getPathname(), FilesystemIterator::SKIP_DOTS );
+
+                foreach ( $json_files as $file ) {
+                    if ( $file->isFile() && $file->getExtension() === 'json' ) {
+                        $json_content = file_get_contents( $file->getPathname() );
+                        $json_data    = json_decode( $json_content, true ); // Decode the JSON content as an associative array
+            
+                        if ( $json_data ) { // If decoding was successful, add it to the array
+                            $all_data[ $key ][] = $json_data;
+                        }
+                    }
+                }
+            }
+
+            return $all_data;
+        }
+
+        public function summarize( array $data ): array {
+            $summarized_data = [];
+            foreach ( $data as $route_group => $entries ) {
+                $metrics = [
+                    'request_overview'   => [ 'time' => [], 'peak_memory' => [], 'memory_percent' => [] ],
+                    'db'                 => [ 'total_time' => [], 'total' => [] ],
+                    'http'               => [ 'total' => [], 'time' => [] ],
+                    'autoloaded_options' => [ 'total_size' => [] ],
+                    'resources_summary'  => [
+                        'scripts' => [ 'total_size' => [] ],
+                        'styles'  => [ 'total_size' => [] ]
+                    ],
+                ];
+            
+                $expensive_queries    = [];
+                $expensive_calls      = [];
+                $large_options        = [];
+                $scripts_large_assets = [];
+                $styles_large_assets  = [];
+            
+                // Collect values for each metric and aggregate arrays
+                foreach ( $entries as $entry ) {
+                    foreach ( $metrics as $category => &$metric_group ) {
+
+                        if ( isset( $metric_group['total_size'] ) && $category == 'resource_summary' ) { // For resources_summary
+                            foreach ( $entry['resources_summary'] as $resource_type => $resource_data ) {
+                                
+                                $metric_group[ $resource_type ]['total_size'][] = $resource_data['total_size'];
+
+                                if ($resource_type === 'scripts') {
+                                    $scripts_large_assets = array_merge( $scripts_large_assets, $resource_data['large_assets'] );
+                                } elseif ($resource_type === 'styles') {
+                                    $styles_large_assets = array_merge( $styles_large_assets, $resource_data['large_assets'] );
+                                }
+                            }
+                        } else { // For other metrics
+                            foreach ( $metric_group as $metric => &$values ) {
+                                if ( isset( $entry[ $category ][ $metric ] ) ) {
+                                    $values[] = $entry[$category][$metric];
+                                }
+                            }
+                        }
+                    }
+            
+                    $expensive_queries = array_merge( $expensive_queries, $entry['db']['expensive_queries'] ?? [] );
+                    $expensive_calls   = array_merge( $expensive_calls, $entry['http']['expensive_calls'] ?? [] );
+                    $large_options     = array_merge( $large_options, $entry['autoloaded_options']['large_options'] ?? [] );
+                }
+        
+                // Calculate p95 for each metric
+                foreach ( $metrics as $category => &$metric_group ) {
+                    foreach ( $metric_group as $metric => &$values ) {
+                        if ( is_array( $values ) ) {
+                            sort( $values );
+                            $index  = ceil( 0.95 * count( $values ) ) - 1;
+                            $values = $values[ $index ] ?? null;
+                        }
+                    }
+                }
+            
+                // Construct the summary object
+                $summarized_data[ $route_group ] = [
+                    'p95' => $metrics,
+                    'expensive_queries' => $expensive_queries,
+                    'expensive_calls'   => $expensive_calls,
+                    'large_options'     => $large_options,
+                    'resource_summary'  => [
+                        'scripts' => [ 'large_assets' => $this->unique_array( $scripts_large_assets ) ],
+                        'styles'  => [ 'large_assets' => $this->unique_array( $styles_large_assets ) ]
+                    ],
+                    'num_requests_summarized' => count( $entries )
+                ];
+            }
+
+            return $summarized_data;
+        }
+
+        public function unique_array( array $original_array ): array {
+            $temp_array   = []; // Initialize temp_array
+            $unique_array = [];
+
+            foreach ( $original_array as $element ) {
+                $serialized_element                = serialize( $element );
+                $temp_array[ $serialized_element ] = true; // Use serialized string as key
+            }
+        
+            foreach ( array_keys( $temp_array ) as $serialized_element ) {
+                $unique_array[] = unserialize( $serialized_element );
+            }
+        
+            return $unique_array;
+        }
+        
+
+        public function get_summary() {
+            $type = 'ui';
+
+            if ( 
+                isset( $_GET['type'] ) &&
+                in_array( $_GET['type'], [ 'ui', 'api' ] )
+            ) {
+                $type = $_GET['type'];
+            }
+
+            $data    = $this->aggregate_data( $type );
+            $summary = $this->summarize( $data );
+            return $summary;
+        }
+    }
+}
+
+QM_Result_Summary::instance()->init();

--- a/plugins/woocommerce/qit-qm-summary/qit-qm-summary.php
+++ b/plugins/woocommerce/qit-qm-summary/qit-qm-summary.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Plugin Name: QIT Query Monitor Summary
+ * Description: Summarizes the data collected by QM across multiple pages.
+ * Version: 0.1
+ * Author: MrJnrman
+ */
+
+ if ( class_exists( 'QM_Collectors' ) ) {
+    require_once __DIR__ . '/qm-summary.php';
+    require_once __DIR__ . '/api/result-summary.php';
+
+    QIT\QM_Summary::init();
+}

--- a/plugins/woocommerce/qit-qm-summary/qm-summary.php
+++ b/plugins/woocommerce/qit-qm-summary/qm-summary.php
@@ -1,0 +1,341 @@
+<?php
+
+namespace QIT;
+
+use QM_Collectors;
+
+class QM_Summary {
+
+	private static $instance            = null;
+	protected string $plugins_dir       = 'wp-content/plugins';
+	protected $js_asset_size_threshold  = 1 * KB_IN_BYTES;
+	protected $css_asset_size_threshold = 1 * KB_IN_BYTES;
+
+	public function __construct() {
+		$request_uri    = $_SERVER['REQUEST_URI'];
+		$is_api_request = strpos( $request_uri, 'wp-json' ) !== false;
+
+		// Skip collection on routes registered by the QIT QM plugin
+		if ( strpos( $request_uri, 'qm/v1' ) !== false ) {
+			return;
+		}
+
+		if ( $is_api_request ) {
+			add_action( 'shutdown', array( $this, 'generate_api_summary' ) );
+		} else {
+			add_filter( 'qm/outputter/html', [ $this, 'generate_browser_summary' ], 999, 2 );
+			add_action( 'shutdown', [ $this, 'capture_resources' ] );
+		}
+	}
+
+	public static function  init() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+	}
+
+	public function fetch_db_queries(): array {
+		$summary = [
+			'total_time'        => 0,
+			'total'             => 0,
+			'types'             => [],
+			'query_threshold'   => 0.01,
+			'expensive_queries' => [],
+		];
+
+		$collector   = QM_Collectors::get( 'db_queries' );
+		$data        = $collector->get_data();
+		$query_types = [];
+
+		if ( empty( $data->rows ) ) {
+			return $summary;
+		}
+
+		if ( ! empty( $data->types ) ) {
+			$query_types = $data->types;
+		}
+
+		$summary['total']      = $data->total_qs;
+		$summary['total_time'] = $data->total_time;
+
+		if ( count( $query_types ) > 0 ) {
+			foreach (  $query_types as $type => $count ) {
+
+				$summary['types'][] = [
+					'type'  => $type,
+					'count' => $count
+				];
+			}
+		}
+
+		$expensive_queries = $data->expensive;
+
+		// Uncomment to see the structure of the $expensive_queries array
+		// $expensive_queries = $data->rows;
+
+		foreach ( $expensive_queries as $expensive ) {
+			$summary['expensive_queries'][] = [
+				'sql'       => $expensive['sql'],
+				'time'      => $expensive['ltime'],
+				'caller'    => $expensive['caller']
+			];
+		}
+
+		return $summary;
+	}
+
+	public function fetch_request_summary(): array {
+		$summary = [
+			'total_time'     => 0,
+			'peak_memory'    => 0,
+			'memory_percent' => 0,
+		];
+
+		$collector = QM_Collectors::get( 'overview' );
+		$data      = $collector->get_data();
+
+		$summary['time']           = $data->time_taken;
+		$summary['peak_memory']    = $data->memory;
+		$summary['memory_percent'] = $data->memory_usage;
+
+		return $summary;
+	}
+
+	public function fetch_http_calls(): array {
+		$summary = [
+			'total'                    => 0,
+			'time'                     => 0,
+			'expensive_call_threshold' => 0.1,
+			'expensive_calls'          => []
+		];
+
+		$collector = QM_Collectors::get( 'http' );
+		$data      = $collector->get_data();
+
+		if ( empty( $data->http ) ) {
+			return $summary;
+		}
+
+		$summary['total'] = count( $data->http );
+		$summary['time']  = $data->ltime;
+
+		foreach ( $data->http as $http ) {
+			if ( $http['ltime'] > $summary['expensive_call_threshold'] ) {
+				$summary['expensive_calls'][] = [
+					'method'  => $http['args']['method'],
+					'url'     => ! empty( $http['redirected_tp' ] ) ? $http['redirected_tp' ] : $http['url'],
+					'time'    => $http['ltime'],
+					'type'    => $http['type'],
+					'size'    => $http['info']['size_download'] ?? 0,
+					'timeout' => $http['args']['timeout']
+				];
+			}
+		}
+
+		return $summary;
+	}
+
+	public function fetch_options_summary(): array {
+		$summary = [
+			'total_size'      => 0,
+			'total_size_comp' => 0,
+			'threshold'       => MB_IN_BYTES,
+			'large_options'   => []
+		];
+
+		$collector = QM_Collectors::get( 'alloptions' );
+		$data      = $collector->get_data();
+
+		if ( empty( $data->options ) ) {
+			return $summary;
+		}
+
+		$summary['total_size']      = $data->total_size;
+		$summary['total_size_comp'] = $data->total_size_comp;
+
+		foreach ( $data->options as $option ) {
+			if ( $option->size > $summary['threshold'] ) {
+				$summary['large_options'][] = [
+					'name' => $option->name,
+					'size' => $option->size
+				];
+			}
+		}
+
+		return $summary;
+	}
+
+	public function fetch_hooks_summary(): array {
+		$summary = [
+			'total' => 0,
+			'hooks' => []
+		];
+
+		$collector   = QM_Collectors::get( 'hooks' );
+		$data        = $collector->get_data();
+
+		if ( empty( $data->hooks ) ) {
+			return $summary;
+		}
+
+		$summary['total'] = count( $data->hooks );
+
+		foreach ( $data->hooks as $hook ) {
+			$h = [
+				'name'      => $hook['name'],
+				'callbacks' => [],
+			];
+
+			if ( count( $hook['actions'] ) > 0 ) {
+				foreach ( $hook['actions'] as $action ) {
+					$callback = $action['callback'];
+					// Filter only hooks registered in the plugins directory.
+					if ( strpos( $callback['file'], $this->plugins_dir ) !== false ) {
+						$h['callbacks'][] = [
+							'name'	    => $callback['name'],
+							'file'       => $callback['file'],
+							'component' => $callback['component'],
+							'priority'  => $action['priority']
+						];
+					}
+				}
+
+				$summary['hooks'][] = $h;
+			}
+		}
+
+		return $summary;
+	}
+
+	public function fetch_resources_summary(): array {
+		$summary   = [
+			'scripts'    => [],
+			'styles'     => [],
+			'total'      => 0,
+			'total_size' => 0
+		];
+
+		$scripts_collector = QM_Collectors::get( 'assets_scripts' );
+		$styles_collector  = QM_Collectors::get( 'assets_styles' );
+
+		$scripts_data = $scripts_collector->get_data();
+		$styles_data  = $styles_collector->get_data();
+
+		if ( ! empty( $scripts_data->assets ) ) {
+			$summary['scripts']    = $this->asset_summary( $scripts_data, 'scripts' );
+			$summary['total']      += $summary['scripts']['total'];
+			$summary['total_size'] += $summary['scripts']['total_size'];
+		}
+
+		if ( ! empty( $styles_data->assets ) ) {
+			$summary['styles']     = $this->asset_summary( $styles_data, 'styles' );
+			$summary['total']      += $summary['styles']['total'];
+			$summary['total_size'] += $summary['styles']['total_size'];
+		}
+
+
+		return $summary;
+	}
+
+	public function asset_summary( $asset_data, $type ): array {
+		$summary  = [
+			'total'        => 0,
+			'total_size'   => 0,
+			'threshold'    => $type === 'scripts' ? $this->js_asset_size_threshold : $this->css_asset_size_threshold,
+			'large_assets' => [],
+		];
+		$positions = [
+			'header',
+			'footer',
+		];
+
+		foreach ( $positions as $position ) {
+
+			$assets = $asset_data->assets[ $position ];
+
+			foreach ( $assets as $handle => $data ) {
+
+				if ( strpos( $data['source'], $this->plugins_dir ) !== false ) {
+
+					$path = ABSPATH . '/' .  $data['display'];
+					$size = file_exists( $path ) ? filesize( $path ) : 'File not found';
+
+					if ( $size > $summary['threshold'] ) {
+						$summary['large_assets'][] = [
+							'name'     => $handle,
+							'source'   => $data['display'],
+							'size'     => $size,
+							'position' => $position
+						];
+					}
+
+					$summary['total']++;
+					$summary['total_size'] += $size;
+				}
+			}
+		}
+
+		return $summary;
+	}
+
+	public function generate_summary( string $path, bool $is_api = false ) {
+		$request_summary   = $this->fetch_request_summary();
+		$db_summary        = $this->fetch_db_queries();
+		$http_summary      = $this->fetch_http_calls();
+		$options_summary   = $this->fetch_options_summary();
+		$hooks_summary     = $this->fetch_hooks_summary();
+		$resources_summary = $is_api ? [] : $this->fetch_resources_summary();
+		$route			   = $_SERVER['REQUEST_URI'];
+ 
+		$key         = time();
+		$route_group = $this->get_route_group( $route );
+		$sub_dir     = $this->base64url_encode( $route_group );
+		$file_path   = sprintf( "%s/%s/%s.json", $path, $sub_dir, $key );
+
+		$summary = [
+			'route_group'        => $route_group,
+			'route'              => $route,
+			'request_overview'   => $request_summary,
+			'db'                 => $db_summary,
+			'http'               => $http_summary,
+			'autoloaded_options' => $options_summary,
+			// 'hooks'              => $hooks_summary,
+			'resources_summary'  => $resources_summary
+		];
+
+		$this->write_file( $file_path, json_encode( $summary, JSON_PRETTY_PRINT ) );
+	}
+
+	public function generate_browser_summary( array $output, QM_Collectors $collectors ): array {
+		$dir_path = __DIR__ . '/results/ui';
+		$this->generate_summary( $dir_path );
+		return $output;
+	}
+
+	public function generate_api_summary() {
+		$dir_path = __DIR__ . '/results/api';
+		$this->generate_summary( $dir_path, true );
+	}
+
+	public function write_file( $path, $contents ) {
+		$dir_path = dirname( $path );
+
+		if ( ! file_exists( $dir_path ) ) {
+			mkdir( $dir_path, 0777, true );
+		}
+
+		file_put_contents( $path, $contents );
+	}
+
+	public function get_route_group( string $route ): string {
+		return preg_replace('/\d+/', ':id', $route);
+	}
+
+	function base64url_encode( string $url ): string {
+		return rtrim( strtr( base64_encode( $url ), '+/', '-_' ), '=' );
+	}
+	  
+	public function base64url_decode( string $url ): string {
+		return base64_decode( str_pad( strtr( $url, '-_', '+/' ), strlen( $url ) % 4, '=', STR_PAD_RIGHT ) );
+	}
+}

--- a/plugins/woocommerce/qm-alloptions/class-qm-collector-alloptions.php
+++ b/plugins/woocommerce/qm-alloptions/class-qm-collector-alloptions.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Data collector class
+ */
+class QM_Collector_AllOptions extends QM_Collector {
+
+	public $id = 'alloptions';
+
+	public function name() {
+		return __( 'AllOptions', 'query-monitor' );
+	}
+
+	/**
+	 * @return QM_Data
+	 */
+	public function get_storage(): QM_Data {
+		return new QM_Data_AllOptions();
+	}
+
+	public function process() {
+
+		$alloptions = wp_load_alloptions( true );
+		$total_size = 0;
+		$options    = [];
+
+		foreach ( $alloptions as $name => $val ) {
+			$size        = is_null( $val ) ? 0 : mb_strlen( $val );
+			$total_size += $size;
+
+			$option = new stdClass();
+
+			$option->name = $name;
+			$option->size = $size;
+
+			$options[] = $option;
+		}
+
+		// sort by size
+		usort( $options, function ( $arr1, $arr2 ) {
+			if ( $arr1->size === $arr2->size ) {
+				return 0;
+			}
+
+			return ( $arr1->size < $arr2->size ) ? -1 : 1;
+		});
+
+		$options = array_reverse( $options );
+
+		$this->data->options    = $options;
+		$this->data->total_size = $total_size;
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$this->data->total_size_comp = strlen( gzdeflate( serialize( $alloptions ) ) );
+	}
+}

--- a/plugins/woocommerce/qm-alloptions/class-qm-data-alloptions.php
+++ b/plugins/woocommerce/qm-alloptions/class-qm-data-alloptions.php
@@ -1,0 +1,18 @@
+<?php
+
+class QM_Data_AllOptions extends QM_Data {
+	/**
+	 * @var array
+	 */
+	public $options;
+
+	/**
+	 * @var int
+	 */
+	public $total_size;
+
+	/**
+	 * @var int
+	 */
+	public $total_size_comp;
+}

--- a/plugins/woocommerce/qm-alloptions/class-qm-output-html-alloptions.php
+++ b/plugins/woocommerce/qm-alloptions/class-qm-output-html-alloptions.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Output class
+ *
+ * Class QM_Output_AllOptions
+ */
+class QM_Output_Html_AllOptions extends QM_Output_Html {
+
+	public function __construct( QM_Collector $collector ) {
+		parent::__construct( $collector );
+		add_filter( 'qm/output/title', array( $this, 'admin_title' ), 101 );
+		add_filter( 'qm/output/menu_class', array( $this, 'admin_class' ) );
+		add_filter( 'qm/output/menus', array( $this, 'admin_menu' ), 101 );
+	}
+
+	/**
+	 * Outputs data in the footer
+	 */
+	public function output() {
+		$data = $this->collector->get_data();
+		?>
+		<div class="qm qm-non-tabular" id="qm-<?php echo esc_attr( $this->collector->id ); ?>" role="tabpanel" aria-labelledby="qm-<?php echo esc_attr( $this->collector->id ); ?>-caption" tabindex="-1">
+			<?php
+			if ( $this->size_is_concerning() ) {
+				// 1000000 set in alloptions-limit.php#L71
+				$percentage = round( ( $data->total_size_comp / 1000000 ) * 100 );
+				echo '<section class="qm-notice"><p>';
+				printf(
+					wp_kses(
+						/* translators: 1. percentage */
+						__( '⚠️ The total size of autoloaded options is at %d%% of maximum. <a href="https://docs.wpvip.com/technical-references/code-quality-and-best-practices/working-with-wp_options/#h-identify-and-resolve-problems-with-alloptions">Review and clean up options</a> listed below to avoid impacting performance or uptime.', 'qm-monitor' ),
+						[ 'a' => [ 'href' => true ] ]
+					),
+					intval( $percentage )
+				);
+				echo '</p></section>';
+			}
+			?>
+			<div class="qm-boxed">
+			<section>
+				<table>
+					<caption class="screen-reader-text"><?php esc_html_e( 'Show total size of autoloaded options and its impact.', 'qm-monitor' ); ?></caption>
+					<thead>
+						<tr>
+							<th scope="col"><h3><?php esc_html_e( 'Total Size', 'qm-monitor' ); ?></h3></th>
+							<th scope="col" class="qm-num"><?php esc_html_e( 'Size (bytes)', 'qm-monitor' ); ?></th>
+							<th scope="col" class="qm-num"><?php esc_html_e( 'Size (human)', 'qm-monitor' ); ?></th>
+							<th scope="col"><?php esc_html_e( 'Impact', 'qm-monitor' ); ?></th>
+						</tr>
+					</thead>
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Uncompressed', 'qm-monitor' ); ?></td>
+						<td class="qm-num"><?php echo esc_html( $data->total_size ); ?></td>
+						<td class="qm-num"><?php echo esc_html( size_format( $data->total_size, 2 ) ); ?></td>
+						<td><?php esc_html_e( 'Consumes PHP memory', 'qm-monitor' ); ?></td>
+					</tr>
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Compressed', 'qm-monitor' ); ?></td>
+						<td class="qm-num"><?php echo esc_html( $data->total_size_comp ); ?></td>
+						<td class="qm-num"><?php echo esc_html( size_format( $data->total_size_comp, 2 ) ); ?></td>
+						<td><?php echo wp_kses( __( 'At 1000000 bytes, an error page will be shown to prevent overrunning the database. <a href="https://docs.wpvip.com/technical-references/code-quality-and-best-practices/working-with-wp_options/#h-identify-and-resolve-problems-with-alloptions">Read more</a>', 'qm-monitor' ), [ 'a' => [ 'href' => true ] ] ); ?></td>
+					</tr>
+				</table>
+			</section>
+			<section>
+				<?php
+					esc_html_e( 'To un-autoload an option, you can use the following command:', 'qm-monitor' );
+					echo '<br><code>wp option autoload set &lt;option_name&gt; no</code><br>';
+					esc_html_e( 'In some cases, the code which sets the option will need to be updated.', 'qm-monitor' );
+				?>
+			</section>
+			</div>
+			<p><?php esc_html_e( 'Starred (*) options are commonly large core options which should not be changed.', 'qm-monitor' ); ?></p>
+			<table>
+				<caption class="screen-reader-text"><?php esc_html_e( 'Show size of each value in autoloaded options.', 'qm-monitor' ); ?></caption>
+				<thead>
+					<tr>
+						<th scope="col"><?php esc_html_e( 'Option name', 'qm-monitor' ); ?></th>
+						<th scope="col" class="qm-num"><?php esc_html_e( 'Size (bytes)', 'qm-monitor' ); ?></th>
+						<th scope="col" class="qm-num"><?php esc_html_e( 'Size (human)', 'qm-monitor' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php
+					foreach ( $data->options as $option ) {
+						echo '<tr>';
+						printf(
+							'<th scope="row" class="qm-ltr">%1$s%2$s</td><td class="qm-ltr qm-num">%3$d</td><td class="qm-ltr qm-num">%4$s</td>',
+							esc_html( $option->name ),
+							( $this->option_is_core( $option->name ) ? ' *' : '' ),
+							esc_html( $option->size ),
+							esc_html( size_format( $option->size, 2 ) )
+						);
+						echo '</tr>';
+					}
+					?>
+				</tbody>
+			</table>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Adds data to top admin bar
+	 *
+	 * @param array $title
+	 * @return array
+	 */
+	public function admin_title( array $title ) {
+
+		if ( $this->size_is_concerning() ) {
+			$data               = $this->collector->get_data();
+			list( $num, $unit ) = explode( ' ', size_format( $data->total_size_comp, 1 ) );
+
+			$title[] = sprintf(
+				/* translators: 1. size 2. size unit */
+				_x( '%1$s<small> %2$s opts</small>', 'size of alloptions', 'qm-monitor' ),
+				$num,
+				$unit
+			);
+		}
+
+		return $title;
+	}
+
+	/**
+	 * @param array $class
+	 * @return array
+	 */
+	public function admin_class( array $class ) {
+		if ( $this->size_is_concerning() ) {
+			$class[] = 'qm-warning';
+		}
+		return $class;
+	}
+
+	/**
+	 * @param array $menu
+	 * @return array
+	 */
+	public function admin_menu( array $menu ) {
+		$title = __( 'Autoloaded Options', 'qm-monitor' );
+
+		if ( $this->size_is_concerning() ) {
+			$title = __( 'Autoloaded Options ⚠️', 'qm-monitor' );
+		}
+
+		$menu[] = $this->menu( array(
+			'id'    => 'qm-alloptions',
+			'href'  => '#qm-alloptions',
+			'title' => $title,
+		));
+
+		return $menu;
+	}
+
+	/**
+	 * Check if size is at warning threshold
+	 *
+	 * 80% of the error page threshold defined in alloptions-limit.php#L71
+	 *
+	 * @return bool
+	 */
+	private function size_is_concerning() {
+		$data = $this->collector->get_data();
+		return ( $data->total_size_comp > 800000 );
+	}
+
+	/**
+	 * Check if option is a commonly large core option
+	 *
+	 * @return bool
+	 */
+	private function option_is_core( $option_name ) {
+		$commonly_large_opts = [
+			'rewrite_rules',
+			'widget_block',
+		];
+		if ( in_array( $option_name, $commonly_large_opts, true ) ) {
+			return true;
+		}
+		global $wpdb;
+		if ( $option_name === $wpdb->prefix . 'user_roles' ) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/plugins/woocommerce/qm-alloptions/qm-alloptions.php
+++ b/plugins/woocommerce/qm-alloptions/qm-alloptions.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Plugin Name: Query Monitor: AllOptions
+ * Description: Shows sizes of values in alloptions (autoloaded-options)
+ * Version: 0.1
+ * Author: trepmal
+ */
+
+add_action('plugins_loaded', function () {
+	/**
+	 * Register collector, only if Query Monitor is enabled.
+	 */
+	if ( class_exists( 'QM_Collectors' ) ) {
+		if ( file_exists( __DIR__ . '/class-qm-data-alloptions.php' ) ) {
+			require_once __DIR__ . '/class-qm-data-alloptions.php';
+		}
+		require_once 'class-qm-collector-alloptions.php';
+
+		QM_Collectors::add( new QM_Collector_AllOptions() );
+	}
+
+	/**
+	 * Register output. The filter won't run if Query Monitor is not
+	 * installed so we don't have to explicity check for it.
+	 */
+	add_filter( 'qm/outputter/html', function ( array $output ) {
+		if ( file_exists( __DIR__ . '/class-qm-output-html-alloptions.php' ) ) {
+			require_once __DIR__ . '/class-qm-output-html-alloptions.php';
+		}
+		$collector = QM_Collectors::get( 'alloptions' );
+		if ( $collector ) {
+			$output['alloptions'] = new QM_Output_Html_AllOptions( $collector );
+		}
+		return $output;
+	}, 101 );
+});


### PR DESCRIPTION
This is an experiment that adds uses query monitor to plugins to extend its functionality and collect performance data for each request to the site.

Plugins: 
`qit-qm-summary` - Collects data for each requests and registers a `/qm/v1/results-summary` route which can be used to view a summary of all requests made.
`qm-alloptions` a VIP plugin that tracks autoloaded options on each request.


### Usage
1. Checkout this repo
2. Do the following:
```
# Ensure that you're using the correct version of Node
nvm use
# Install the PHP and Composer dependencies for all of the plugins, packages, and tools
pnpm install
# Build all of the plugins, packages, and tools in the monorepo
pnpm build
```
3. Go to the woocommerce plugin directory with `cd plugins/woocommerce`
4. Spin up the test environment with `pnpm env:start`
5. Run either e2e/api tests with `pnpm test:e2e-pw` or `pnpm test:api-pw` respectively.
6. Make a get request with to `http://localhost:8086/wp-json/qm/v1/result-summary` to see the summarized results of each test. You can specify which type of results you want to see by adding the `?type=api/e2e` query param.

**Note**: There is a caveat with this POC. If you want to discard the collected data and generate fresh results, you have to delete the `plugins/woocommerce/qit-qm-summary/results` directory.